### PR TITLE
修了几个bug

### DIFF
--- a/frontend/wapp/components/movableList/movableList.js
+++ b/frontend/wapp/components/movableList/movableList.js
@@ -173,6 +173,10 @@ Component({
       //console.log("cur tarList:", JSON.stringify(this.data.tarList))
       this.drawList()
       this.deactiveMovable()
+    },
+
+    nop(event) {
+      console.log("catch event:", event)
     }
   },
 

--- a/frontend/wapp/components/movableList/movableList.js
+++ b/frontend/wapp/components/movableList/movableList.js
@@ -7,6 +7,10 @@ Component({
    * 组件的属性列表
    */
   properties: {
+    planNo: {
+      type: Number,
+      value: 0,
+    },
     tarList: {
       type: Array,
       value: [],
@@ -27,8 +31,8 @@ Component({
   data: {
     moveDisabled: true,
     statusLongpress: false,  /* 是否在longpress状态，用于在touchend中过滤短按结束的情况 */
-    moveId: 0,
-    endY: 0,
+    moveId: 0, /* 当前移动的代码 */
+    endY: 0,  
 
     // 检测手势
     touchStartX: 0,
@@ -49,6 +53,11 @@ Component({
         tarList: tarListWithPosition
       })
       //console.log("draw list:", JSON.stringify(this.properties.tarList))
+      // 同步到父页面
+      this.triggerEvent("synctarlistchange", {
+        listNo: this.properties.planNo, 
+        newList: this.data.tarList
+      })
     },
 
     activateMovable() {
@@ -65,15 +74,22 @@ Component({
       console.log("movable deactivate")
     },
 
+    onTouchStart(event) {
+      console.log("[touch start]")
+      console.log(event)
+      // 记录初始位置
+      this.setData({
+        touchStartX: event.changedTouches[0].pageX,
+        touchStartY: event.changedTouches[0].pageY,
+      })
+    },
+
     onLongPress(event) {
       console.log("[longpress]")
       console.log(event)
 
       this.activateMovable()
-      const {
-        currentTarget: {dataset}
-      } = event 
-      // 不用details.y，因为此时的y来自press的坐标，不来自我们需要的item左上角的坐标
+      const {currentTarget: {dataset}} = event // 新型写法，初始化dataset 
       const newEndY = this.properties.tarList[dataset.moveid].y
       // 但仍需要将endY改为对应item中的y（因为touchEnd还会被触发）
       this.setData({
@@ -93,16 +109,6 @@ Component({
       this.setData({
         moveId: dataset.moveid,
         endY: globalUtil.px2rpx(detail.y)
-      })
-    },
-
-    onTouchStart(event) {
-      console.log("[touch start]")
-      console.log(event)
-      // 记录初始位置
-      this.setData({
-        touchStartX: event.changedTouches[0].pageX,
-        touchStartY: event.changedTouches[0].pageY,
       })
     },
 
@@ -157,7 +163,7 @@ Component({
     endMoveAndReorderList() {
       var newList = this.properties.tarList // 其实感觉没必要深拷贝
       console.log("change endY to", this.data.endY)
-      newList[this.data.moveId].y = this.data.endY
+      newList[this.data.moveId].y = this.data.endY // 修改移动项的y值
       newList.sort((a, b) => {return a.y - b.y})
       //console.log("after sorting:", JSON.stringify(newList)) 
       this.setData({

--- a/frontend/wapp/components/movableList/movableList.js
+++ b/frontend/wapp/components/movableList/movableList.js
@@ -29,6 +29,10 @@ Component({
     statusLongpress: false,  /* 是否在longpress状态，用于在touchend中过滤短按结束的情况 */
     moveId: 0,
     endY: 0,
+
+    // 检测手势
+    touchStartX: 0,
+    touchStartY: 0,
   },
 
   /**
@@ -47,14 +51,14 @@ Component({
       //console.log("draw list:", JSON.stringify(this.properties.tarList))
     },
 
-    activateMovable(event) {
+    activateMovable() {
       this.setData({
         moveDisabled: false
       })
       console.log("movable activate: now you can move item")
     },
 
-    deactiveMovable(event) {
+    deactiveMovable() {
       this.setData({
         moveDisabled: true
       })
@@ -63,8 +67,9 @@ Component({
 
     onLongPress(event) {
       console.log("[longpress]")
-      this.activateMovable()
       console.log(event)
+
+      this.activateMovable()
       const {
         currentTarget: {dataset}
       } = event 
@@ -81,8 +86,6 @@ Component({
     // 注意：只有位置在发生改变才会持续触发bindchange
     onMoving(event) {  
       /* moving时，调用间隔很短，是否应考虑优化 */
-      //console.log("[moving...]")
-      //console.log(event)
       const {
         detail,
         currentTarget: {dataset}
@@ -93,29 +96,41 @@ Component({
       })
     },
 
+    onTouchStart(event) {
+      console.log("[touch start]")
+      console.log(event)
+      // 记录初始位置
+      this.setData({
+        touchStartX: event.changedTouches[0].pageX,
+        touchStartY: event.changedTouches[0].pageY,
+      })
+    },
+
     onTouchEnd(event) {
       console.log("[touch end]")
-      if (!this.data.statusLongpress) { // 过滤非长按结束的情况
-        console.log("not after longpress, it's a tab -- view spot\n")
-        this.onTabViewScene(event)
+      console.log(event)
+      // 记录结束位置
+      const touchEndX = event.changedTouches[0].pageX
+      const touchEndY = event.changedTouches[0].pageY
+
+      // 检测到longpress动作 (longpress > tap)
+      if (this.data.statusLongpress) {
+        console.log("detect longpress")
+        this.endMoveAndReorderList()
         return
       }
-      // 确定为长按结束的情况
-      var newList = this.properties.tarList // 其实感觉没必要深拷贝
-      console.log("change endY to", this.data.endY)
-      newList[this.data.moveId].y = this.data.endY
-      newList.sort((a, b) => {return a.y - b.y})
-      //console.log("after sorting:", JSON.stringify(newList)) 
-      // 这里list的y值不对劲的原因是浅拷贝，导致之后的drawList修改也会影响newList
-      // console.log打印obj时，其实仅传入地址，所以缩略图时运行时的（对的），打开折叠所见值是当下的（错的）
-      this.setData({
-        tarList: newList, // 这里是浅拷贝（也可能不是，因为没引子组件）
-        statusLongpress: false
-      })
-      //console.log("cur tarList:", JSON.stringify(this.data.tarList))
-      this.drawList()
-      this.deactiveMovable()
-      //console.log("\n")
+
+      // 检测到tap动作
+      if (touchEndX === this.data.touchStartX &&
+          touchEndY === this.data.touchStartY ) {
+        console.log("detect tab: view scenery details")
+        this.viewSceneDetail(event)
+        return
+      }
+      
+      // default
+      console.log("meaningless event, ignored")
+      return
     },
 
     deleteListItem(event) {
@@ -130,13 +145,28 @@ Component({
     },
     
     // 权益之计，组件耦合度太太太高了
-    onTabViewScene(event) {
+    viewSceneDetail(event) {
       console.log("tabView:", event)
       var idx = event.currentTarget.dataset.moveid
       var planId = this.data.tarList[idx].id
       wx.navigateTo({
         url: "/pages/sceneryShow/sceneryShow?scenery_id=" + planId,
       })
+    },
+
+    endMoveAndReorderList() {
+      var newList = this.properties.tarList // 其实感觉没必要深拷贝
+      console.log("change endY to", this.data.endY)
+      newList[this.data.moveId].y = this.data.endY
+      newList.sort((a, b) => {return a.y - b.y})
+      //console.log("after sorting:", JSON.stringify(newList)) 
+      this.setData({
+        tarList: newList, // 这里是浅拷贝（也可能不是，因为没引子组件）
+        statusLongpress: false
+      })
+      //console.log("cur tarList:", JSON.stringify(this.data.tarList))
+      this.drawList()
+      this.deactiveMovable()
     }
   },
 

--- a/frontend/wapp/components/movableList/movableList.wxml
+++ b/frontend/wapp/components/movableList/movableList.wxml
@@ -12,7 +12,7 @@
     y="{{item.y}}rpx" data-moveid="{{index}}"
   > 
       
-      <van-swipe-cell class="swipe-cell-container" left-width="72" >  <!-- 单位还是px -->
+      <van-swipe-cell class="swipe-cell-container" left-width="36" >  <!-- 单位还是px -->
         <view class="button-container" slot="left">
           <button class="delete-item-button" type="warn" bindtap="deleteListItem" data-id="{{index}}">
             删除

--- a/frontend/wapp/components/movableList/movableList.wxml
+++ b/frontend/wapp/components/movableList/movableList.wxml
@@ -14,7 +14,9 @@
       
       <van-swipe-cell class="swipe-cell-container" left-width="36" >  <!-- 单位还是px -->
         <view class="button-container" slot="left">
-          <button class="delete-item-button" type="warn" bindtap="deleteListItem" data-id="{{index}}">
+          <button class="delete-item-button" type="warn" 
+            catchtouchstart="nop" catchlongpress="nop" catchtouchend="deleteListItem" 
+            data-id="{{index}}">
             删除
           </button>
         </view>

--- a/frontend/wapp/components/movableList/movableList.wxml
+++ b/frontend/wapp/components/movableList/movableList.wxml
@@ -7,8 +7,8 @@
     style="height: {{itemHeight}}rpx; margin-top: {{itemMarginTop}}rpx; z-index: {{index == moveId ? 12 : 11}};"
     wx:for="{{tarList}}" wx:key="unique"
     direction="vertical" disabled="{{moveDisabled}}" 
-    bindtap="onTabViewScene"
-    bindlongpress="onLongPress" bindchange="onMoving" bindtouchend="onTouchEnd" 
+    bindlongpress="onLongPress" bindchange="onMoving" 
+    bindtouchstart="onTouchStart" bindtouchend="onTouchEnd" 
     y="{{item.y}}rpx" data-moveid="{{index}}"
   > 
       

--- a/frontend/wapp/pages/travelPlanList/travelPlanList.js
+++ b/frontend/wapp/pages/travelPlanList/travelPlanList.js
@@ -134,7 +134,8 @@ Page({
             travelPlanList: res.data
           })
         }
-        console.log(this.data.travelPlanList)
+        console.log(JSON.stringify(this.data.travelPlanList))
+
         // 调整preview内容
         this.data.travelPlanList.forEach((item, index) => {
           this.setData({

--- a/frontend/wapp/pages/travelPlanPreview/travelPlanPreview.js
+++ b/frontend/wapp/pages/travelPlanPreview/travelPlanPreview.js
@@ -171,6 +171,7 @@ Page({
     // 生成formData
     var spotList = []
     var selectPlan = this.data.travelPlansList[this.data.plansActive]
+    console.log("select plan:", selectPlan)
     selectPlan.forEach((item) => {
       spotList.push(item.id)
     });
@@ -206,6 +207,7 @@ Page({
   },
 
   upgradeMarkers() {
+    console.log("update markers and points")
     let mapContext = wx.createMapContext("preview-map", this)
 
     // 利用travel plan添加markers和points
@@ -233,6 +235,17 @@ Page({
       padding: [40,],
       points: this.data.mapPoints
     })
+  },
+
+  onSyncTarListChange(event) {
+    console.log("father page: receive new tarList")
+    console.log(event)
+    var tarPlanNo = event.detail.listNo
+    this.setData({
+      ["travelPlansList[" + tarPlanNo + "]"]: event.detail.newList
+    })
+
+    console.log("after sync, travelPlansList:", this.data.travelPlansList)
   },
 
   /**

--- a/frontend/wapp/pages/travelPlanPreview/travelPlanPreview.wxml
+++ b/frontend/wapp/pages/travelPlanPreview/travelPlanPreview.wxml
@@ -20,7 +20,9 @@
 <view class="travel-plans-display-container">
   <van-tabs animated active="{{plansActive}}" bind:change="onTabChange" color="rgba(30,144,255,1.0)">
     <van-tab wx:for="{{travelPlansList}}" wx:key="*this" title="方案{{index+1}}">
-      <my-movable-list tarList="{{item}}"></my-movable-list>
+      <my-movable-list planNo="{{index}}" tarList="{{item}}" 
+        bind:synctarlistchange="onSyncTarListChange">
+      </my-movable-list>
     </van-tab>
   </van-tabs>
 </view>

--- a/frontend/wapp/pages/travelPlanShow/travelPlanShow.js
+++ b/frontend/wapp/pages/travelPlanShow/travelPlanShow.js
@@ -201,7 +201,7 @@ Page({
         // })
         wx.navigateBack({
           success: () => {
-            let currentPage = getCurrentPages();
+            let currPages = getCurrentPages();
             wx.redirectTo({
               url: "/" + currPages[currPages.length - 1].route,
             })


### PR DESCRIPTION
目前还剩2个：
1. movablelist 移动项目后显示项目大概率乱
2. movablelist 删除项目后 其父页面travelPlanPreview的tab栏标题会变（只显示 方案1/方案2 方案3不见了等）
    - 关于这点，首次删“方案1”或“方案3”的某项必定不会出错